### PR TITLE
add packagesupplier field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: |
           mkdir sbom
           npm i
-          sbom-tool generate -b ./sbom -bc . -pn sbom-tool-installer-action -pv v1.0.0 -nsb https://github.com/philips-software/sbom-tool-installer-action
+          sbom-tool generate -b ./sbom -bc . -pn sbom-tool-installer-action -ps Philips -pv v1.0.0 -nsb https://github.com/philips-software/sbom-tool-installer-action
       - uses: actions/upload-artifact@v3
         with:
           name: sbom


### PR DESCRIPTION
This is now a new mandatory field in the latest versions of the sbom-tool.