### PR TITLE
Add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: google-github-actions/release-please-action@514bc6cdae71484c998108f2136a8f5e4c62b9b9 # ratchet:google-github-actions/release-please-action@v3
+        with:
+          release-type: node

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,16 @@ npm test
 ```
 
 See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/README.md#packages) for the various packages.
+
+## Releases
+
+This project uses [Release Please](https://github.com/googleapis/release-please) to create releases.
+This will automate the release process based on [Conventional Commit messages](https://www.conventionalcommits.org/).
+
+Please make sure to use:
+- `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch. 
+- `feat:` which represents a new feature, and correlates to a SemVer minor.
+- `feat!:`, or `fix!`:, `refactor!`:, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.
+
+When you want to force a PR with a certain version use [the following instructions](https://github.com/googleapis/release-please#how-do-i-change-the-version-number).
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you have a suggestion that would make this project better, please fork the re
 
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+3. Commit your Changes (`git commit -m 'feat: Add some AmazingFeature'`)
 4. Push to the Branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 


### PR DESCRIPTION
# Add Release-please workflow

This will create a PR once a commit is merge which starts with:

- `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
- `feat:` which represents a new feature, and correlates to a SemVer minor.
- `feat!:`, or `fix!`:, `refactor!`:, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.

## Note

I've added a commit message with the following part:

```
Release-As: 1.0.1
```

This is because this will force release-please to create a new release once it's merged to `main`.