### PR TITLE
chore: Increase timeout for download test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
+  testTimeout: 10000,
   verbose: true
 }


### PR DESCRIPTION
The download test sometimes exceeds 5000ms because of throttling on Github. Now changed timeout to 10000ms.